### PR TITLE
Rename of ParseMagickOption() in Imagemagick 6.8.5

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.60)
-AC_INIT(mod_dims, 3.1.0, [jeremy.collins@corp.aol.com])
+AC_INIT(mod_dims, 3.3.0, [jeremy.collins@beetlebug.org])
 AM_INIT_AUTOMAKE
 AC_CONFIG_SRCDIR([src/mod_dims.c])
 

--- a/examples/dims.conf
+++ b/examples/dims.conf
@@ -3,21 +3,14 @@
     LoadModule dims_module mod_dims/modules/mod_dims.so
 </IfModule>
 
-DimsDownloadTimeout 5000
+DimsDownloadTimeout 60000
 DimsImagemagickTimeout 20000
 
-#DimsImagemagickAreaSize 30
-#DimsImagemagickMemorySize 512
-#DimsImagemagickMapSize 1024
-#DimsImagemagickDiskSize 2048
+# DimsClient <appId> [<noImageUrl> <cache control max-age> <edge control downstream-ttl> <trustSource?> <minSourceCache> <maxSourceCache> <password>]
+DimsAddClient TEST http://placehold.it/350x150 604800 604800 trust 604800 604800 t3st
 
-# DimsClient <appId> [<noImageUrl> <cache control max-age> <edge control downstream-ttl> <trustSource?> <minSourceCache> <maxSourceCache>]
-DimsAddClient TEST http://o.aolcdn.com/art/ch_music2/albumartmissing 3600 3600 trust 1800 3600
-DimsAddClient PGMC http://o.aolcdn.com/art/ch_music2/albumartmissing 3600 3600
-
-DimsDefaultImageURL http://o.aolcdn.com/art/ch_music2/albumartmissing
-
-DimsCacheExpire 3600
+DimsDefaultImageURL http://placehold.it/350x150
+DimsCacheExpire 604800
 DimsNoImageCacheExpire 60
 
 DimsAddWhitelist *.beetlebug.org *.aolcdn.com
@@ -33,6 +26,10 @@ AddHandler dims-local .gif .jpg .png
 
 <Location /dims3/>
     SetHandler dims3
+</Location>
+
+<Location /dims4/>
+    SetHandler dims4
 </Location>
 
 <Location /dims-status/>

--- a/src/mod_dims.c
+++ b/src/mod_dims.c
@@ -580,6 +580,28 @@ dims_fetch_remote_image(dims_request_rec *d, const char *url)
             
             if(response_code == 404) {
                 d->status = DIMS_FILE_NOT_FOUND;
+                ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, d->r,
+                    "Received a 404 NOT FOUND on request: %s ",
+                    d->r->uri);
+            }
+
+            /* This shouldn't happen with CURLOPT_FOLLOWLOCATION => 1 */
+            else if(response_code == 301 || response_code == 302) {
+                ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, d->r,
+                    "Received a %d REDIRECT on request: %s ",
+                    response_code, d->r->uri);
+            }
+
+            else if(response_code >= 500) {
+                ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, d->r,
+                    "Received a %d SERVER ERROR on request: %s ",
+                    response_code, d->r->uri);
+            }
+
+            else {
+                ap_log_rerror(APLOG_MARK, APLOG_WARNING, 0, d->r,
+                    "Received a %d non-ok status on request: %s ",
+                    response_code, d->r->uri);
             }
 
             free(fetch_url);

--- a/src/mod_dims.c
+++ b/src/mod_dims.c
@@ -535,6 +535,7 @@ dims_fetch_remote_image(dims_request_rec *d, const char *url)
         curl_easy_setopt(curl_handle, CURLOPT_HEADERDATA, (void *) d);
         curl_easy_setopt(curl_handle, CURLOPT_TIMEOUT_MS, d->config->download_timeout + extra_time);
         curl_easy_setopt(curl_handle, CURLOPT_NOSIGNAL, 1);
+        curl_easy_setopt(curl_handle, CURLOPT_FOLLOWLOCATION, 1);
 
         /* The curl shared handle allows this process to share DNS cache
          * and prevents the DNS cache from going away after every request.

--- a/src/mod_dims.c
+++ b/src/mod_dims.c
@@ -34,7 +34,7 @@
  */
 
 #define MODULE_RELEASE "$Revision: $"
-#define MODULE_VERSION "3.3.0"
+#define MODULE_VERSION "3.3.1"
 
 #include "mod_dims.h"
 #include "util_md5.h"

--- a/src/mod_dims_ops.c
+++ b/src/mod_dims_ops.c
@@ -337,7 +337,7 @@ dims_liquid_rescale_operation (dims_request_rec *d, char *args, char **err) {
 
 apr_status_t
 dims_gravity_operation (dims_request_rec *d, char *args, char **err) {
-    int gravity = ParseMagickOption(MagickGravityOptions,MagickFalse,args);
+    int gravity = ParseCommandOption(MagickGravityOptions,MagickFalse,args);
     MAGICK_CHECK(MagickSetImageGravity(d->wand, gravity), d);
     return DIMS_SUCCESS;
 }


### PR DESCRIPTION
Hi Jeremy,

this pull request is only to keep track of this breaking change in ImageMagick 6.8.5 (at least). I didn't go back to check which version renamed it, but the changeset is the following: http://trac.imagemagick.org/changeset/4281/ImageMagick/trunk/magick/image.c

`ParseMagickOption()` was renamed to `ParseCommandOption()`.

This was the only change I needed to do to compile my mod_dims with ImageMagick 8.6.5-10 (latest as of this writing).

I'm currently testing it.
