### PR TITLE
Convert spaces to '+' in crop commands

### DIFF
--- a/src/mod_dims.c
+++ b/src/mod_dims.c
@@ -1194,8 +1194,19 @@ dims_handle_request(dims_request_rec *d)
             }
         }
 
+        // Convert %20 (space) back to '+' in commands. This is fixes an issue with "+" being encoded as %20 by some clients.
+        char *commands = apr_pstrdup(d->r->pool, d->unparsed_commands);
+        char *s = commands;
+        while (*s) {
+            if (*s == ' ') {
+                *s = '+';
+            }
+
+            s++;
+        }
+
         // Standard signature params.
-        char *signature_params = apr_pstrcat(d->pool, expires_str, d->client_config->secret_key, d->unparsed_commands, d->image_url, NULL);
+        char *signature_params = apr_pstrcat(d->pool, expires_str, d->client_config->secret_key, commands, d->image_url, NULL);
 
         // Concatenate additional params.
         char *token;

--- a/src/mod_dims_ops.c
+++ b/src/mod_dims_ops.c
@@ -205,6 +205,25 @@ dims_crop_operation (dims_request_rec *d, char *args, char **err) {
     RectangleInfo rec;
     ExceptionInfo ex_info;
 
+    /* Replace blank spaces with '+'. This happens when some user agents
+     * inadvertantly escape the '+' as %20 which gets converted to a blank space.
+     * 
+     * Example: 
+     * 
+     * 900x900%20350%200 is '900x900 350 0' which is an invalid, the following code
+     * coverts this to '900x900+350+0'.
+     *
+     */
+    char *s = args;
+    while (*s) {
+        if (*s == ' ') {
+            *s = '+';
+	}
+
+	s++;
+    }
+
+
     flags = ParseGravityGeometry(GetImageFromMagickWand(d->wand), args, &rec, &ex_info);
     if(!(flags & AllValues)) {
         *err = "Parsing crop geometry failed";

--- a/src/mod_dims_ops.c
+++ b/src/mod_dims_ops.c
@@ -205,8 +205,8 @@ dims_crop_operation (dims_request_rec *d, char *args, char **err) {
     RectangleInfo rec;
     ExceptionInfo ex_info;
 
-    /* Replace blank spaces with '+'. This happens when some user agents
-     * inadvertantly escape the '+' as %20 which gets converted to a blank space.
+    /* Replace spaces with '+'. This happens when some user agents inadvertantly 
+     * escape the '+' as %20 which gets converted to a space.
      * 
      * Example: 
      * 
@@ -218,9 +218,9 @@ dims_crop_operation (dims_request_rec *d, char *args, char **err) {
     while (*s) {
         if (*s == ' ') {
             *s = '+';
-	}
+        }
 
-	s++;
+        s++;
     }
 
 


### PR DESCRIPTION
This happens when a user agent encodes the plus as %20.