### PR TITLE
Add default output format support with exceptions

### DIFF
--- a/src/mod_dims.c
+++ b/src/mod_dims.c
@@ -1070,7 +1070,7 @@ dims_process_image(dims_request_rec *d)
      */
     MagickAutoOrientImage(d->wand);
 
-    /* Flatten images (i.e animated gif) only if there's an overlay. Otherwise, pass through. */
+    /* Flatten images (i.e animated gif) if there's an overlay or file type is `psd`. Otherwise, pass through. */
     size_t images = MagickGetNumberImages(d->wand);
     bool should_flatten = false;
 

--- a/src/mod_dims.c
+++ b/src/mod_dims.c
@@ -1653,8 +1653,8 @@ dims_handler(request_rec *r)
                     key[16] = '\0';
 
                     // Force key to uppercase
-                    char *s = key;
-                    while (*s) { *s = toupper((unsigned char) *s); s++; }
+                    unsigned char *s = key;
+                    while (*s) { *s = toupper(*s); s++; }
 
                     fixed_url = aes_128_decrypt(r, key, encrypted_text, encrypted_length);
                     if (fixed_url == NULL) {

--- a/src/mod_dims.c
+++ b/src/mod_dims.c
@@ -2014,7 +2014,7 @@ static const command_rec dims_commands[] =
                       "Add a client with optional no image url, max-age and downstream-ttl settings."),
     AP_INIT_TAKE_ARGV("DimsIgnoreDefaultOutputFormat",
                       dims_config_set_ignore_default_output_format, NULL, RSRC_CONF,
-                      "Add an input format that shouldn't be converted to the default output format."),
+                      "Add input formats that shouldn't be converted to the default output format."),
     AP_INIT_TAKE1("DimsDefaultImageURL",
                   dims_config_set_no_image_url, NULL, RSRC_CONF,
                   "Default image if processing fails or original image doesn't exist."),
@@ -2072,7 +2072,7 @@ static const command_rec dims_commands[] =
                 "The default is 0."),
     AP_INIT_TAKE1("DimsDefaultOutputFormat",
                 dims_config_set_default_output_format, NULL, RSRC_CONF,
-                "Default output format if not provided in the request."),
+                "Default output format if 'format' command is not present in the request."),
     {NULL}
 };
 

--- a/src/mod_dims.c
+++ b/src/mod_dims.c
@@ -238,7 +238,10 @@ dims_config_set_default_output_format(cmd_parms *cmd, void *dummy, const char *a
 {
     dims_config_rec *config = (dims_config_rec *) ap_get_module_config(
             cmd->server->module_config, &dims_module);
-    config->default_output_format = (char *) arg;
+    char *output_format = (char *) arg;
+    char *s = output_format;
+    while (*s) { *s = toupper(*s); s++; }
+    config->default_output_format = output_format;
     return NULL;
 }
 

--- a/src/mod_dims.c
+++ b/src/mod_dims.c
@@ -1087,7 +1087,7 @@ dims_process_image(dims_request_rec *d)
 
         char *input_format = MagickGetImageFormat(d->wand);
 
-        if (strcmp(input_format, "PSD") || strcmp(input_format, "psd")) {
+        if (strcmp(input_format, "PSD") == 0 || strcmp(input_format, "psd") == 0) {
             should_flatten = true;
         }
 

--- a/src/mod_dims.c
+++ b/src/mod_dims.c
@@ -1599,7 +1599,7 @@ dims_handler(request_rec *r)
         return dims_handle_request(d);
     } else if ((strcmp(r->handler, "dims3") == 0) ||
             (r->uri && strncmp(r->uri, "/dims3/", 7) == 0) ||
-            (strcmp( r->handler,"dims4") == 0 )) {
+            (strcmp(r->handler, "dims4") == 0 )) {
         /* Handle new-style DIMS parameters. */
         char *p, *url = NULL, *fixed_url = NULL, *commands = NULL, *eurl = NULL;
         if (( strcmp( r->handler,"dims4") == 0)) {

--- a/src/mod_dims.c
+++ b/src/mod_dims.c
@@ -1648,7 +1648,7 @@ dims_handler(request_rec *r)
                     }
 
                     // Use first 16 bytes.
-                    unsigned char key[16];
+                    unsigned char key[17];
                     strncpy(key, hex, 16);
                     key[16] = '\0';
 

--- a/src/mod_dims.c
+++ b/src/mod_dims.c
@@ -1053,6 +1053,12 @@ dims_process_image(dims_request_rec *d)
             }
         }
 
+        char *input_format = MagickGetImageFormat(d->wand);
+
+        if (strcmp(input_format, "PSD") || strcmp(input_format, "psd")) {
+            should_flatten = true;
+        }
+
         if (should_flatten) {
             for (int i = 1; i <= images - 1; i++) {
                 MagickSetIteratorIndex(d->wand, i);

--- a/src/mod_dims.h
+++ b/src/mod_dims.h
@@ -104,6 +104,7 @@ struct dims_config_rec {
     float optimize_resize;
     int include_disposition;
     int disable_encoded_fetch;
+    char *default_output_format;
 
     MagickSizeType area_size;
     MagickSizeType memory_size;

--- a/src/mod_dims.h
+++ b/src/mod_dims.h
@@ -96,6 +96,7 @@ struct dims_config_rec {
 
     apr_table_t *whitelist;
     apr_hash_t *clients;
+    apr_table_t *ignore_default_output_format;
 
     char *no_image_url;
     long no_image_expire;


### PR DESCRIPTION
Support a default output format with ability to keep the original format.
Note that `format` command will be honored If it is present in the request.

For example, the given configuration:
```
<VirtualHost *:80>
    ...
    DimsDefaultOutputFormat jpg
    DimsIgnoreDefaultOutputFormat png gif
    ...
</VirtualHost>
```
Any images but `png` and `gif` will be converted to `jpg` format if no `format` command is present in the request.