### PR TITLE
Fix Imagemagick init bug

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.60)
-AC_INIT(mod_dims, 3.3.24, [jeremy.collins@beetlebug.org])
+AC_INIT(mod_dims, 3.3.25, [jeremy.collins@beetlebug.org])
 AM_INIT_AUTOMAKE([no-define])
 AC_CONFIG_SRCDIR([src/mod_dims.c])
 

--- a/src/mod_dims.c
+++ b/src/mod_dims.c
@@ -34,7 +34,7 @@
  */
 
 #define MODULE_RELEASE "$Revision: $"
-#define MODULE_VERSION "3.3.24"
+#define MODULE_VERSION "3.3.25"
 
 #include "mod_dims.h"
 #include "util_md5.h"

--- a/src/mod_dims.c
+++ b/src/mod_dims.c
@@ -1837,6 +1837,7 @@ dims_init(apr_pool_t *p, apr_pool_t *plog, apr_pool_t* ptemp, server_rec *s)
 
     ap_add_version_component(p, "mod_dims/" MODULE_VERSION);
 
+    MagickWandGenesis();
     MagickSetResourceLimit(AreaResource, config->area_size);
     MagickSetResourceLimit(DiskResource, config->disk_size);
     MagickSetResourceLimit(MemoryResource, config->memory_size);


### PR DESCRIPTION
Imagemagick will hang when setting MagickSetResourceLimit if MagickWandGenesis hasn't been called.