### PR TITLE
Add DimsDefaultImagePrefix configuration

### DIFF
--- a/src/mod_dims.h
+++ b/src/mod_dims.h
@@ -116,6 +116,7 @@ struct dims_config_rec {
     char *secret_key;
     long max_expiry_period;
     char *cache_dir;
+    char *default_image_prefix;
 };
 
 struct dims_client_config_rec {


### PR DESCRIPTION
When set this will prefix a relative url with the provided value. The default image prefix must begin with http:// or https://.