### PR TITLE
Encode spaces in a URL if 'DimsDisableEncodedFetch' is set.

### DIFF
--- a/src/mod_dims.c
+++ b/src/mod_dims.c
@@ -544,6 +544,25 @@ char *url_encode(char *str) {
             *pbuf++ = *pstr;
         else
             *pbuf++ = '%', *pbuf++ = to_hex(*pstr >> 4), *pbuf++ = to_hex(*pstr & 15);
+
+        pstr++;
+    }
+    *pbuf = '\0';
+    return buf;
+}
+
+/* Returns a str after encoding a space to '%20' since libcurl doesn't encode it automatically as browsers do. */
+/* IMPORTANT: be sure to free() the returned string after use */
+char *url_encode_space_only(char *str) {
+    char *pstr = str, *buf = malloc(strlen(str) * 3 + 1), *pbuf = buf;
+    while (*pstr) {
+        if (*pstr == ' ') {
+            *pbuf++ = '%', *pbuf++ = '2', *pbuf++ = '0';
+
+        } else {
+            *pbuf++ = *pstr;
+        }
+
         pstr++;
     }
     *pbuf = '\0';
@@ -576,6 +595,9 @@ dims_get_image_data(dims_request_rec *d, char *fetch_url, dims_image_data_t *dat
     if (!d->config->disable_encoded_fetch) {
         fetch_url = url_encode(fetch_url);
         ap_log_rerror(APLOG_MARK, APLOG_DEBUG, 0, d->r, "Encoded URL: %s ", fetch_url);
+
+    } else {
+        fetch_url = url_encode_space_only(fetch_url);
     }
 
     curl_handle = curl_easy_init();
@@ -603,9 +625,7 @@ dims_get_image_data(dims_request_rec *d, char *fetch_url, dims_image_data_t *dat
 
     *data = image_data;
 
-    if (!d->config->disable_encoded_fetch) {
-        free(fetch_url);
-    }
+    free(fetch_url);
 
     return code;
 }


### PR DESCRIPTION
This is to address an issue with space in a URL since libcurl doesn't convert it automatically as browsers do.

For example,
Given the url:
```
https://dims.example.com/dims4/local/67480e7/2147483647/strip/true/resize/1536x%5E/format/webp/?url=http%3A%2F%2Fexample.com%2Fscreen-shot-2021-07-16-at-12.28.12%20PM.png
```
DIMS makes a request to read the image at `http://example.com/screen-shot-2021-07-16-at-12.28.12 PM.png`, which contains a space, and libcurl throws an error.