### PR TITLE
Add support for AES/GCM/NoPadding decryption of eurl parameter

### DIFF
--- a/autorun.sh
+++ b/autorun.sh
@@ -42,3 +42,5 @@ done
 "$AUTORECONF" -i || exit $?
 "$AUTOMAKE" || exit $?
 "$AUTOCONF" || exit $?01
+
+./configure $@

--- a/src/mod_dims.h
+++ b/src/mod_dims.h
@@ -114,6 +114,7 @@ struct dims_config_rec {
 
     int curl_queue_size;
     char *secret_key;
+    char *encryption_algorithm;
     long max_expiry_period;
     char *cache_dir;
     char *default_image_prefix;


### PR DESCRIPTION
Doubts:
1. Should the new Encryption Algorithm Setting be a client setting or global setting? Was unsure on the distinction between those.
2. Is `encryption_algorithm` and appropriate name for the configuration? There's technically two distinct algos used, one for the signature, which this doesn't impact, and one for the watermarked URL, which this PR addresses. 
3. Is the error logging helpful or excessive/unnecessary?